### PR TITLE
Fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bindings for using [Formik](https://github.com/jaredpalmer/formik) with [Reactst
 
 ## Getting Started
 
-    npm install formik-material-ui
+    npm install reactstrap-formik
     
 ## Usage Examples
   * Text Input [Example](https://codesandbox.io/s/xl6mx6w8z4)


### PR DESCRIPTION
This corrects the package name from `formik-material-ui` to `reactstrap-formik`. 🎄 